### PR TITLE
Fix Adding Books for Win32

### DIFF
--- a/src/renderer/App.vue
+++ b/src/renderer/App.vue
@@ -33,7 +33,7 @@ export default {
     else{
         this.isReady = true;
     }
-    
+
     this.$bus.on('theme-change',(theme)=>{
       this.$refs.app.className = "";
       this.$refs.app.classList.add(theme);
@@ -65,7 +65,7 @@ html,
 body {
   margin: 0px;
   width: 100%;
-  height: 100%;  
+  height: 100%;
   -webkit-font-smoothing: antialiased;
   overflow: hidden;
 }

--- a/src/renderer/views/Reader.vue
+++ b/src/renderer/views/Reader.vue
@@ -89,7 +89,11 @@ export default {
 
   },
   mounted() {
-    const { id } = this.$route.params;
+    let { id } = this.$route.params;
+
+    if (process.platform === 'win32') {
+        id = id.split('\\').pop();
+    }
     this.info = this.$db.get(id);
     this.toc = this.info.toc;
     this.info.lastOpen = new Date().getTime();

--- a/src/renderer/views/Reader.vue
+++ b/src/renderer/views/Reader.vue
@@ -7,22 +7,22 @@
 			</el-button-group>
 
 			<toc-menu :toc="toc" :theme="theme" @node-click="onNodeClick"></toc-menu>
-			
-			<bookmark-menu 
-				:bookmarks="info.bookmarks" 
-				:theme="theme" 
+
+			<bookmark-menu
+				:bookmarks="info.bookmarks"
+				:theme="theme"
 				@node-click="onNodeClick"
 				@add-bookmark="addBookmark"
 				@remove-bookmark="removeBookmark"
 			/>
-			
+
 			<search-menu
 				:search-result="searchResult"
 				:theme="theme"
 				@node-click="onNodeClick"
 				@search="search"
 			/>
-			
+
 			<theme-menu
 				@theme-change="applytheme"
 				@flow-change="applyflow"
@@ -305,9 +305,9 @@ export default {
     },
 
     tocFromPercentage(percent){
-      
+
       if(!this._flattenedToc) return {};
-      
+
       percent /= 100;
 
       for(let i = 0 ; i < this._flattenedToc.length ; i+=1 ){

--- a/src/shared/dbUtilis.js
+++ b/src/shared/dbUtilis.js
@@ -43,7 +43,7 @@ function storeCover(book, path, cb) {
  * @returns {String} which will be used as a id to store file info in db
  */
 
-function genrateKey(filePath) {
+function generateKey(filePath) {
   if (!filePath || typeof filePath !== 'string') {
     return '';
   }
@@ -161,7 +161,7 @@ function getInfo(filePath, callback) {
   }
 
   // create a key from path
-  const key = genrateKey(filePath);
+  const key = generateKey(filePath);
 
   // file load on file protocol
   const uri = fileUrl(filePath);
@@ -221,8 +221,8 @@ function addToDB(file, db, cb) {
       key
     );
 
-    storeCover(book, coverPath, isSucces => {
-      if (isSucces) {
+    storeCover(book, coverPath, isSuccess => {
+      if (isSuccess) {
         info.coverPath = fileUrl(coverPath);
         Vibrant.from(coverPath)
           .getPalette((err, palette) => {
@@ -249,4 +249,4 @@ function addToDB(file, db, cb) {
   });
 }
 
-export { addToDB, storeCover, genrateKey, getInfo, parshToc };
+export { addToDB, storeCover, generateKey, getInfo, parshToc };

--- a/src/shared/dbUtilis.js
+++ b/src/shared/dbUtilis.js
@@ -5,6 +5,7 @@ import toBuffer from 'blob-to-buffer';
 import { Book } from 'epubjs';
 import fileUrl from 'file-url';
 import path from 'path';
+import process from 'process';
 import * as Vibrant from 'node-vibrant';
 
 /**
@@ -203,7 +204,7 @@ function getInfo(filePath, callback) {
 
 function addToDB(file, db, cb) {
   getInfo(file, (info, book) => {
-    const key = info.id;
+    let key = info.id;
     info.lastOpen = new Date().getTime();
 
     // return if book is allready registered
@@ -212,6 +213,10 @@ function addToDB(file, db, cb) {
         cb(info, db);
       }
       return;
+    }
+
+    if (process.platform === 'win32') {
+        key = key.split('\\').pop();
     }
 
     const coverPath = path.join(


### PR DESCRIPTION
This PR correctly allows users to add and read ePubs on at least Windows 10 x64 which fixes [this issue](https://github.com/Janglee123/eplee/issues/17). You can see screenshots [here](https://imgur.com/a/tiCGmww)

The ID/Key was being set as the fully qualified path to the epub and it needed to be parsed to only take the name after the final `\` character.

There is also a bit of whitespace cleanup in here since my editor strips it automatically on save. There is also a commit that corrected some typos.