### PR TITLE
added iframe focus call on every rendition render

### DIFF
--- a/src/renderer/views/Reader.vue
+++ b/src/renderer/views/Reader.vue
@@ -114,6 +114,7 @@ export default {
     });
 
     this.rendition.on('rendered', (e, iframe) => {
+      iframe.iframe.contentWindow.focus()
       clickListener(iframe.document, this.rendition, this.flipPage);
       selectListener(iframe.document, this.rendition, this.toggleBuble);
       swipListener(iframe.document,  this.flipPage);


### PR DESCRIPTION
This fixes the issue where iframe lost focus on every rendition render meaning that we needed to click inside it for the listeners to work again.